### PR TITLE
Fix linear interpolation in SimpleIndex.cpp

### DIFF
--- a/volePSI/SimpleIndex.cpp
+++ b/volePSI/SimpleIndex.cpp
@@ -264,10 +264,10 @@ namespace volePSI
             // Then evalate the surface at out bin,ball coordinate.
             if (numBinsHgh < sizes.size() && numBallsHgh < sizes[numBinsHgh].size())
             {
-                auto a0 = (diffBin)*sizes[numBinsLow][numBallsLow] + (1 - diffBin) * sizes[numBinsLow][numBallsHgh];
-                auto a1 = (diffBin)*sizes[numBinsHgh][numBallsLow] + (1 - diffBin) * sizes[numBinsHgh][numBallsHgh];
+                auto a0 = (1 - diffBin) * sizes[numBinsLow][numBallsLow] + (diffBin) * sizes[numBinsLow][numBallsHgh];
+                auto a1 = (1 - diffBin) * sizes[numBinsHgh][numBallsLow] + (diffBin) * sizes[numBinsHgh][numBallsHgh];
 
-                auto b0 = (diffBall)*a0 + (1 - diffBall) * a1;
+                auto b0 = (1 - diffBall) * a0 + (diffBall) * a1;
 
                 auto B = std::ceil(std::pow(2, b0));
 


### PR DESCRIPTION
To interpolate `f(x)` linearly between `f(x0)` and `f(x1)`, the [correct equation](https://en.wikipedia.org/wiki/Linear_interpolation) is `f(x) = 1 / (x1 - x0) * (x1 - x) * f(x0) + (x - x0) * f(x1)`. With `x1 - x0 = 1` and `diff := x - x0`, this means `f(x) = (1 - diff) * f(x0) + diff * f(x1)`.